### PR TITLE
review suggestions for cluster volume support

### DIFF
--- a/api/server/router/volume/backend.go
+++ b/api/server/router/volume/backend.go
@@ -26,9 +26,9 @@ type Backend interface {
 // backends here.
 type ClusterBackend interface {
 	GetVolume(nameOrID string) (volume.Volume, error)
-	GetVolumes(options types.VolumeListOptions) ([]*volume.Volume, error)
+	GetVolumes(options volume.ListOptions) ([]*volume.Volume, error)
 	CreateVolume(volume volume.CreateOptions) (*volume.Volume, error)
 	RemoveVolume(nameOrID string, force bool) error
-	UpdateVolume(nameOrID string, version uint64, volume volume.VolumeUpdateBody) error
+	UpdateVolume(nameOrID string, version uint64, volume volume.UpdateOptions) error
 	IsManager() bool
 }

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/docker/docker/api/server/httputils"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/api/types/volume"
@@ -39,7 +38,7 @@ func (v *volumeRouter) getVolumesList(ctx context.Context, w http.ResponseWriter
 
 	version := httputils.VersionFromContext(ctx)
 	if versions.GreaterThanOrEqualTo(version, clusterVolumesVersion) && v.cluster.IsManager() {
-		clusterVolumes, swarmErr := v.cluster.GetVolumes(types.VolumeListOptions{Filters: filters})
+		clusterVolumes, swarmErr := v.cluster.GetVolumes(volume.ListOptions{Filters: filters})
 		if swarmErr != nil {
 			// if there is a swarm error, we may not want to error out right
 			// away. the local list probably worked. instead, let's do what we
@@ -155,7 +154,7 @@ func (v *volumeRouter) putVolumesUpdate(ctx context.Context, w http.ResponseWrit
 		return errdefs.InvalidParameter(err)
 	}
 
-	var req volume.VolumeUpdateBody
+	var req volume.UpdateOptions
 	if err := httputils.ReadJSON(r, &req); err != nil {
 		return err
 	}

--- a/api/server/router/volume/volume_routes_test.go
+++ b/api/server/router/volume/volume_routes_test.go
@@ -1,13 +1,12 @@
 package volume
 
 import (
-	"net/http/httptest"
-	"testing"
-
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http/httptest"
+	"testing"
 
 	"gotest.tools/v3/assert"
 
@@ -333,7 +332,7 @@ func TestUpdateVolume(t *testing.T) {
 		cluster: c,
 	}
 
-	volumeUpdate := volume.VolumeUpdateBody{
+	volumeUpdate := volume.UpdateOptions{
 		Spec: &volume.ClusterVolumeSpec{},
 	}
 
@@ -360,7 +359,7 @@ func TestUpdateVolumeNoSwarm(t *testing.T) {
 		cluster: c,
 	}
 
-	volumeUpdate := volume.VolumeUpdateBody{
+	volumeUpdate := volume.UpdateOptions{
 		Spec: &volume.ClusterVolumeSpec{},
 	}
 
@@ -390,7 +389,7 @@ func TestUpdateVolumeNotFound(t *testing.T) {
 		cluster: c,
 	}
 
-	volumeUpdate := volume.VolumeUpdateBody{
+	volumeUpdate := volume.UpdateOptions{
 		Spec: &volume.ClusterVolumeSpec{},
 	}
 
@@ -665,7 +664,7 @@ func (c *fakeClusterBackend) GetVolume(nameOrID string) (volume.Volume, error) {
 	return volume.Volume{}, errdefs.NotFound(fmt.Errorf("volume %s not found", nameOrID))
 }
 
-func (c *fakeClusterBackend) GetVolumes(options types.VolumeListOptions) ([]*volume.Volume, error) {
+func (c *fakeClusterBackend) GetVolumes(options volume.ListOptions) ([]*volume.Volume, error) {
 	if err := c.checkSwarm(); err != nil {
 		return nil, err
 	}
@@ -732,7 +731,7 @@ func (c *fakeClusterBackend) RemoveVolume(nameOrID string, force bool) error {
 	return nil
 }
 
-func (c *fakeClusterBackend) UpdateVolume(nameOrID string, version uint64, _ volume.VolumeUpdateBody) error {
+func (c *fakeClusterBackend) UpdateVolume(nameOrID string, version uint64, _ volume.UpdateOptions) error {
 	if err := c.checkSwarm(); err != nil {
 		return err
 	}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9480,40 +9480,7 @@ paths:
           type: "string"
       tags: ["Volume"]
 
-    delete:
-      summary: "Remove a volume"
-      description: "Instruct the driver to remove the volume."
-      operationId: "VolumeDelete"
-      responses:
-        204:
-          description: "The volume was removed"
-        404:
-          description: "No such volume or volume driver"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-        409:
-          description: "Volume is in use and cannot be removed"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-        500:
-          description: "Server error"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-      parameters:
-        - name: "name"
-          in: "path"
-          required: true
-          description: "Volume name or ID"
-          type: "string"
-        - name: "force"
-          in: "query"
-          description: "Force the removal of the volume"
-          type: "boolean"
-          default: false
-      tags: ["Volume"]
-
-  /volumes/{name}/update:
-    post:
+    put:
       summary: |
         "Update a volume. Valid only for Swarm cluster volumes"
       operationId: "VolumeUpdate"
@@ -9570,6 +9537,39 @@ paths:
           format: "int64"
           required: true
       tags: ["Volume"]
+
+    delete:
+      summary: "Remove a volume"
+      description: "Instruct the driver to remove the volume."
+      operationId: "VolumeDelete"
+      responses:
+        204:
+          description: "The volume was removed"
+        404:
+          description: "No such volume or volume driver"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        409:
+          description: "Volume is in use and cannot be removed"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        500:
+          description: "Server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+      parameters:
+        - name: "name"
+          in: "path"
+          required: true
+          description: "Volume name or ID"
+          type: "string"
+        - name: "force"
+          in: "query"
+          description: "Force the removal of the volume"
+          type: "boolean"
+          default: false
+      tags: ["Volume"]
+
   /volumes/prune:
     post:
       summary: "Delete unused volumes"

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -750,18 +750,6 @@ type ConfigListOptions struct {
 	Filters filters.Args
 }
 
-// VolumeCreateResponse is contains the information returned to a client on
-// the creation of a new swarm cluster volume.
-type VolumeCreateResponse struct {
-	// ID is the id of the created volume
-	ID string
-}
-
-// VolumeListOptions holds parameters to list volumes.
-type VolumeListOptions struct {
-	Filters filters.Args
-}
-
 // PushResult contains the tag, manifest digest, and manifest size from the
 // push. It's used to signal this information to the trust code in the client
 // so it can sign the manifest if necessary.

--- a/api/types/volume/cluster_volume.go
+++ b/api/types/volume/cluster_volume.go
@@ -20,10 +20,10 @@ type ClusterVolume struct {
 
 	// PublishStatus contains the status of the volume as it pertains to its
 	// publishing on Nodes.
-	PublishStatus []*VolumePublishStatus `json:",omitempty"`
+	PublishStatus []*PublishStatus `json:",omitempty"`
 
 	// Info is information about the global status of the volume.
-	Info *VolumeInfo `json:",omitempty"`
+	Info *Info `json:",omitempty"`
 }
 
 // ClusterVolumeSpec contains the spec used to create this volume.
@@ -37,7 +37,7 @@ type ClusterVolumeSpec struct {
 	Group string `json:",omitempty"`
 
 	// AccessMode defines how the volume is used by tasks.
-	AccessMode *VolumeAccessMode `json:",omitempty"`
+	AccessMode *AccessMode `json:",omitempty"`
 
 	// AccessibilityRequirements specifies where in the cluster a volume must
 	// be accessible from.
@@ -53,101 +53,101 @@ type ClusterVolumeSpec struct {
 
 	// CapacityRange defines the desired capacity that the volume should be
 	// created with. If nil, the plugin will decide the capacity.
-	CapacityRange *VolumeCapacityRange `json:",omitempty"`
+	CapacityRange *CapacityRange `json:",omitempty"`
 
 	// Secrets defines Swarm Secrets that are passed to the CSI storage plugin
 	// when operating on this volume.
-	Secrets []VolumeSecret `json:",omitempty"`
+	Secrets []Secret `json:",omitempty"`
 
 	// Availability is the Volume's desired availability. Analogous to Node
 	// Availability, this allows the user to take volumes offline in order to
 	// update or delete them.
-	Availability VolumeAvailability `json:",omitempty"`
+	Availability Availability `json:",omitempty"`
 }
 
-// VolumeAvailability specifies the availability of the volume.
-type VolumeAvailability string
+// Availability specifies the availability of the volume.
+type Availability string
 
 const (
-	// VolumeAvailabilityActive indicates that the volume is active and fully
+	// AvailabilityActive indicates that the volume is active and fully
 	// schedulable on the cluster.
-	VolumeAvailabilityActive VolumeAvailability = "active"
+	AvailabilityActive Availability = "active"
 
-	// VolumeAvailabilityPause indicates that no new workloads should use the
+	// AvailabilityPause indicates that no new workloads should use the
 	// volume, but existing workloads can continue to use it.
-	VolumeAvailabilityPause VolumeAvailability = "pause"
+	AvailabilityPause Availability = "pause"
 
-	// VolumeAvailabilityDrain indicates that all workloads using this volume
+	// AvailabilityDrain indicates that all workloads using this volume
 	// should be rescheduled, and the volume unpublished from all nodes.
-	VolumeAvailabilityDrain VolumeAvailability = "drain"
+	AvailabilityDrain Availability = "drain"
 )
 
-// VolumeAccessMode defines the access mode of a volume.
-type VolumeAccessMode struct {
+// AccessMode defines the access mode of a volume.
+type AccessMode struct {
 	// Scope defines the set of nodes this volume can be used on at one time.
-	Scope VolumeScope `json:",omitempty"`
+	Scope Scope `json:",omitempty"`
 
 	// Sharing defines the number and way that different tasks can use this
 	// volume at one time.
-	Sharing VolumeSharing `json:",omitempty"`
+	Sharing SharingMode `json:",omitempty"`
 
 	// MountVolume defines options for using this volume as a Mount-type
 	// volume.
 	//
 	// Either BlockVolume or MountVolume, but not both, must be present.
-	MountVolume *VolumeTypeMount `json:",omitempty"`
+	MountVolume *TypeMount `json:",omitempty"`
 
 	// BlockVolume defines options for using this volume as a Block-type
 	// volume.
 	//
 	// Either BlockVolume or MountVolume, but not both, must be present.
-	BlockVolume *VolumeTypeBlock `json:",omitempty"`
+	BlockVolume *TypeBlock `json:",omitempty"`
 }
 
-// VolumeScope defines the Scope of a CSI Volume. This is how many nodes a
+// Scope defines the Scope of a CSI Volume. This is how many nodes a
 // Volume can be accessed simultaneously on.
-type VolumeScope string
+type Scope string
 
 const (
-	// VolumeScopeSingleNode indicates the volume can be used on one node at a
+	// ScopeSingleNode indicates the volume can be used on one node at a
 	// time.
-	VolumeScopeSingleNode VolumeScope = "single"
+	ScopeSingleNode Scope = "single"
 
-	// VolumeScopeMultiNode indicates the volume can be used on many nodes at
+	// ScopeMultiNode indicates the volume can be used on many nodes at
 	// the same time.
-	VolumeScopeMultiNode VolumeScope = "multi"
+	ScopeMultiNode Scope = "multi"
 )
 
-// VolumeSharing defines the Sharing of a CSI Volume. This is how Tasks using a
+// SharingMode defines the Sharing of a CSI Volume. This is how Tasks using a
 // Volume at the same time can use it.
-type VolumeSharing string
+type SharingMode string
 
 const (
-	// VolumeSharingNone indicates that only one Task may use the Volume at a
+	// SharingNone indicates that only one Task may use the Volume at a
 	// time.
-	VolumeSharingNone VolumeSharing = "none"
+	SharingNone SharingMode = "none"
 
-	// VolumeSharingReadOnly indicates that the Volume may be shared by any
+	// SharingReadOnly indicates that the Volume may be shared by any
 	// number of Tasks, but they must be read-only.
-	VolumeSharingReadOnly VolumeSharing = "readonly"
+	SharingReadOnly SharingMode = "readonly"
 
-	// VolumeSharingOneWriter indicates that the Volume may be shared by any
+	// SharingOneWriter indicates that the Volume may be shared by any
 	// number of Tasks, but all after the first must be read-only.
-	VolumeSharingOneWriter VolumeSharing = "onewriter"
+	SharingOneWriter SharingMode = "onewriter"
 
-	// VolumeSharingAll means that the Volume may be shared by any number of
+	// SharingAll means that the Volume may be shared by any number of
 	// Tasks, as readers or writers.
-	VolumeSharingAll VolumeSharing = "all"
+	SharingAll SharingMode = "all"
 )
 
-// VolumeTypeBlock defines options for using a volume as a block-type volume.
+// TypeBlock defines options for using a volume as a block-type volume.
 //
 // Intentionally empty.
-type VolumeTypeBlock struct{}
+type TypeBlock struct{}
 
-// VolumeTypeMount contains options for using a volume as a Mount-type
+// TypeMount contains options for using a volume as a Mount-type
 // volume.
-type VolumeTypeMount struct {
+type TypeMount struct {
 	// FsType specifies the filesystem type for the mount volume. Optional.
 	FsType string `json:",omitempty"`
 
@@ -334,9 +334,9 @@ type Topology struct {
 	Segments map[string]string `json:",omitempty"`
 }
 
-// VolumeCapacityRange describes the minimum and maximum capacity a volume should be
+// CapacityRange describes the minimum and maximum capacity a volume should be
 // created with
-type VolumeCapacityRange struct {
+type CapacityRange struct {
 	// RequiredBytes specifies that a volume must be at least this big. The
 	// value of 0 indicates an unspecified minimum.
 	RequiredBytes uint64
@@ -346,10 +346,10 @@ type VolumeCapacityRange struct {
 	LimitBytes uint64
 }
 
-// VolumeSecret represents a Swarm Secret value that must be passed to the CSI
+// Secret represents a Swarm Secret value that must be passed to the CSI
 // storage plugin when operating on this Volume. It represents one key-value
 // pair of possibly many.
-type VolumeSecret struct {
+type Secret struct {
 	// Key is the name of the key of the key-value pair passed to the plugin.
 	Key string
 
@@ -359,47 +359,47 @@ type VolumeSecret struct {
 	Secret string
 }
 
-// VolumePublishState represents the state of a Volume as it pertains to its
+// PublishState represents the state of a Volume as it pertains to its
 // use on a particular Node.
-type VolumePublishState string
+type PublishState string
 
 const (
-	// VolumePendingPublish indicates that the volume should be published on
+	// StatePending indicates that the volume should be published on
 	// this node, but the call to ControllerPublishVolume has not been
 	// successfully completed yet and the result recorded by swarmkit.
-	VolumePendingPublish VolumePublishState = "pending publish"
+	StatePending PublishState = "pending-publish"
 
-	// VolumePublished means the volume is published successfully to the node.
-	VolumePublished VolumePublishState = "published"
+	// StatePublished means the volume is published successfully to the node.
+	StatePublished PublishState = "published"
 
-	// VolumePendingNodeUnpublish indicates that the Volume should be
+	// StatePendingNodeUnpublish indicates that the Volume should be
 	// unpublished on the Node, and we're waiting for confirmation that it has
 	// done so.  After the Node has confirmed that the Volume has been
-	// unpublished, the state will move to VolumePendingUnpublish.
-	VolumePendingNodeUnpublish VolumePublishState = "pending node unpublish"
+	// unpublished, the state will move to StatePendingUnpublish.
+	StatePendingNodeUnpublish PublishState = "pending-node-unpublish"
 
-	// VolumePendingUnpublish means the volume is still published to the node
+	// StatePendingUnpublish means the volume is still published to the node
 	// by the controller, awaiting the operation to unpublish it.
-	VolumePendingUnpublish VolumePublishState = "pending controller unpublish"
+	StatePendingUnpublish PublishState = "pending-controller-unpublish"
 )
 
-// VolumePublishStatus represents the status of the volume as published to an
+// PublishStatus represents the status of the volume as published to an
 // individual node
-type VolumePublishStatus struct {
+type PublishStatus struct {
 	// NodeID is the ID of the swarm node this Volume is published to.
 	NodeID string `json:",omitempty"`
 
 	// State is the publish state of the volume.
-	State VolumePublishState `json:",omitempty"`
+	State PublishState `json:",omitempty"`
 
 	// PublishContext is the PublishContext returned by the CSI plugin when
 	// a volume is published.
 	PublishContext map[string]string `json:",omitempty"`
 }
 
-// VolumeInfo contains information about the Volume as a whole as provided by
+// Info contains information about the Volume as a whole as provided by
 // the CSI storage plugin.
-type VolumeInfo struct {
+type Info struct {
 	// CapacityBytes is the capacity of the volume in bytes. A value of 0
 	// indicates that the capacity is unknown.
 	CapacityBytes int `json:",omitempty"`

--- a/api/types/volume/options.go
+++ b/api/types/volume/options.go
@@ -1,0 +1,8 @@
+package volume // import "github.com/docker/docker/api/types/volume"
+
+import "github.com/docker/docker/api/types/filters"
+
+// ListOptions holds parameters to list volumes.
+type ListOptions struct {
+	Filters filters.Args
+}

--- a/api/types/volume/volume_update.go
+++ b/api/types/volume/volume_update.go
@@ -1,7 +1,7 @@
 package volume // import "github.com/docker/docker/api/types/volume"
 
-// VolumeUpdateBody is configuration to update a Volume with.
-type VolumeUpdateBody struct {
+// UpdateOptions is configuration to update a Volume with.
+type UpdateOptions struct {
 	// Spec is the ClusterVolumeSpec to update the volume to.
 	Spec *ClusterVolumeSpec `json:"Spec,omitempty"`
 }

--- a/client/interface.go
+++ b/client/interface.go
@@ -179,7 +179,7 @@ type VolumeAPIClient interface {
 	VolumeList(ctx context.Context, filter filters.Args) (volume.ListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
 	VolumesPrune(ctx context.Context, pruneFilter filters.Args) (types.VolumesPruneReport, error)
-	VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.VolumeUpdateBody) error
+	VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.UpdateOptions) error
 }
 
 // SecretAPIClient defines API client methods for secrets

--- a/client/volume_update.go
+++ b/client/volume_update.go
@@ -11,7 +11,7 @@ import (
 
 // VolumeUpdate updates a volume. This only works for Cluster Volumes, and
 // only some fields can be updated.
-func (cli *Client) VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.VolumeUpdateBody) error {
+func (cli *Client) VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.UpdateOptions) error {
 	if err := cli.NewVersionError("1.42", "volume update"); err != nil {
 		return err
 	}

--- a/client/volume_update_test.go
+++ b/client/volume_update_test.go
@@ -19,7 +19,7 @@ func TestVolumeUpdateError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.VolumeUpdate(context.Background(), "", swarm.Version{}, volumetypes.VolumeUpdateBody{})
+	err := client.VolumeUpdate(context.Background(), "", swarm.Version{}, volumetypes.UpdateOptions{})
 
 	if !errdefs.IsSystem(err) {
 		t.Fatalf("expected a Server Error, got %[1]T: %[1]v", err)
@@ -48,7 +48,7 @@ func TestVolumeUpdate(t *testing.T) {
 		}),
 	}
 
-	err := client.VolumeUpdate(context.Background(), "test1", swarm.Version{Index: uint64(10)}, volumetypes.VolumeUpdateBody{})
+	err := client.VolumeUpdate(context.Background(), "test1", swarm.Version{Index: uint64(10)}, volumetypes.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/cluster/convert/volume.go
+++ b/daemon/cluster/convert/volume.go
@@ -49,20 +49,20 @@ func volumeSpecToGRPC(spec volumetypes.ClusterVolumeSpec) *swarmapi.VolumeSpec {
 		swarmSpec.AccessMode = &swarmapi.VolumeAccessMode{}
 
 		switch spec.AccessMode.Scope {
-		case volumetypes.VolumeScopeSingleNode:
+		case volumetypes.ScopeSingleNode:
 			swarmSpec.AccessMode.Scope = swarmapi.VolumeScopeSingleNode
-		case volumetypes.VolumeScopeMultiNode:
+		case volumetypes.ScopeMultiNode:
 			swarmSpec.AccessMode.Scope = swarmapi.VolumeScopeMultiNode
 		}
 
 		switch spec.AccessMode.Sharing {
-		case volumetypes.VolumeSharingNone:
+		case volumetypes.SharingNone:
 			swarmSpec.AccessMode.Sharing = swarmapi.VolumeSharingNone
-		case volumetypes.VolumeSharingReadOnly:
+		case volumetypes.SharingReadOnly:
 			swarmSpec.AccessMode.Sharing = swarmapi.VolumeSharingReadOnly
-		case volumetypes.VolumeSharingOneWriter:
+		case volumetypes.SharingOneWriter:
 			swarmSpec.AccessMode.Sharing = swarmapi.VolumeSharingOneWriter
-		case volumetypes.VolumeSharingAll:
+		case volumetypes.SharingAll:
 			swarmSpec.AccessMode.Sharing = swarmapi.VolumeSharingAll
 		}
 
@@ -121,11 +121,11 @@ func volumeSpecToGRPC(spec volumetypes.ClusterVolumeSpec) *swarmapi.VolumeSpec {
 	// specify an availability, it will be inferred as the 0-value, which is
 	// "active".
 	switch spec.Availability {
-	case volumetypes.VolumeAvailabilityActive:
+	case volumetypes.AvailabilityActive:
 		swarmSpec.Availability = swarmapi.VolumeAvailabilityActive
-	case volumetypes.VolumeAvailabilityPause:
+	case volumetypes.AvailabilityPause:
 		swarmSpec.Availability = swarmapi.VolumeAvailabilityPause
-	case volumetypes.VolumeAvailabilityDrain:
+	case volumetypes.AvailabilityDrain:
 		swarmSpec.Availability = swarmapi.VolumeAvailabilityDrain
 	}
 
@@ -155,25 +155,7 @@ func VolumeCreateToGRPC(volume *volumetypes.CreateOptions) *swarmapi.VolumeSpec 
 	return swarmSpec
 }
 
-// VolumeUpdateToGRPC converts a VolumeUpdateBody to the swarm GRPC object.
-//
-// NOTE(dperny): this is not yet used, as the only thing that can be changed
-// with volumes at this time is availability.
-func VolumeUpdateToGRPC(volume *volumetypes.VolumeUpdateBody) *swarmapi.VolumeSpec {
-	var swarmSpec *swarmapi.VolumeSpec
-	if volume != nil && volume.Spec != nil {
-		swarmSpec = volumeSpecToGRPC(*volume.Spec)
-	} else {
-		swarmSpec = &swarmapi.VolumeSpec{}
-	}
-
-	// TODO(dperny): handle name, driver, etc, which are all in practice
-	// immutable.
-
-	return swarmSpec
-}
-
-func volumeInfoFromGRPC(info *swarmapi.VolumeInfo) *volumetypes.VolumeInfo {
+func volumeInfoFromGRPC(info *swarmapi.VolumeInfo) *volumetypes.Info {
 	if info == nil {
 		return nil
 	}
@@ -186,7 +168,7 @@ func volumeInfoFromGRPC(info *swarmapi.VolumeInfo) *volumetypes.VolumeInfo {
 		}
 	}
 
-	return &volumetypes.VolumeInfo{
+	return &volumetypes.Info{
 		CapacityBytes:      int(info.CapacityBytes),
 		VolumeContext:      info.VolumeContext,
 		VolumeID:           info.VolumeID,
@@ -194,26 +176,26 @@ func volumeInfoFromGRPC(info *swarmapi.VolumeInfo) *volumetypes.VolumeInfo {
 	}
 }
 
-func volumePublishStatusFromGRPC(publishStatus []*swarmapi.VolumePublishStatus) []*volumetypes.VolumePublishStatus {
+func volumePublishStatusFromGRPC(publishStatus []*swarmapi.VolumePublishStatus) []*volumetypes.PublishStatus {
 	if publishStatus == nil {
 		return nil
 	}
 
-	vps := make([]*volumetypes.VolumePublishStatus, len(publishStatus))
+	vps := make([]*volumetypes.PublishStatus, len(publishStatus))
 	for i, status := range publishStatus {
-		var state volumetypes.VolumePublishState
+		var state volumetypes.PublishState
 		switch status.State {
 		case swarmapi.VolumePublishStatus_PENDING_PUBLISH:
-			state = volumetypes.VolumePendingPublish
+			state = volumetypes.StatePending
 		case swarmapi.VolumePublishStatus_PUBLISHED:
-			state = volumetypes.VolumePublished
+			state = volumetypes.StatePublished
 		case swarmapi.VolumePublishStatus_PENDING_NODE_UNPUBLISH:
-			state = volumetypes.VolumePendingNodeUnpublish
+			state = volumetypes.StatePendingNodeUnpublish
 		case swarmapi.VolumePublishStatus_PENDING_UNPUBLISH:
-			state = volumetypes.VolumePendingUnpublish
+			state = volumetypes.StatePendingUnpublish
 		}
 
-		vps[i] = &volumetypes.VolumePublishStatus{
+		vps[i] = &volumetypes.PublishStatus{
 			NodeID:         status.NodeID,
 			State:          state,
 			PublishContext: status.PublishContext,
@@ -223,36 +205,36 @@ func volumePublishStatusFromGRPC(publishStatus []*swarmapi.VolumePublishStatus) 
 	return vps
 }
 
-func accessModeFromGRPC(accessMode *swarmapi.VolumeAccessMode) *volumetypes.VolumeAccessMode {
+func accessModeFromGRPC(accessMode *swarmapi.VolumeAccessMode) *volumetypes.AccessMode {
 	if accessMode == nil {
 		return nil
 	}
 
-	convertedAccessMode := &volumetypes.VolumeAccessMode{}
+	convertedAccessMode := &volumetypes.AccessMode{}
 
 	switch accessMode.Scope {
 	case swarmapi.VolumeScopeSingleNode:
-		convertedAccessMode.Scope = volumetypes.VolumeScopeSingleNode
+		convertedAccessMode.Scope = volumetypes.ScopeSingleNode
 	case swarmapi.VolumeScopeMultiNode:
-		convertedAccessMode.Scope = volumetypes.VolumeScopeMultiNode
+		convertedAccessMode.Scope = volumetypes.ScopeMultiNode
 	}
 
 	switch accessMode.Sharing {
 	case swarmapi.VolumeSharingNone:
-		convertedAccessMode.Sharing = volumetypes.VolumeSharingNone
+		convertedAccessMode.Sharing = volumetypes.SharingNone
 	case swarmapi.VolumeSharingReadOnly:
-		convertedAccessMode.Sharing = volumetypes.VolumeSharingReadOnly
+		convertedAccessMode.Sharing = volumetypes.SharingReadOnly
 	case swarmapi.VolumeSharingOneWriter:
-		convertedAccessMode.Sharing = volumetypes.VolumeSharingOneWriter
+		convertedAccessMode.Sharing = volumetypes.SharingOneWriter
 	case swarmapi.VolumeSharingAll:
-		convertedAccessMode.Sharing = volumetypes.VolumeSharingAll
+		convertedAccessMode.Sharing = volumetypes.SharingAll
 	}
 
 	if block := accessMode.GetBlock(); block != nil {
-		convertedAccessMode.BlockVolume = &volumetypes.VolumeTypeBlock{}
+		convertedAccessMode.BlockVolume = &volumetypes.TypeBlock{}
 	}
 	if mount := accessMode.GetMount(); mount != nil {
-		convertedAccessMode.MountVolume = &volumetypes.VolumeTypeMount{
+		convertedAccessMode.MountVolume = &volumetypes.TypeMount{
 			FsType:     mount.FsType,
 			MountFlags: mount.MountFlags,
 		}
@@ -261,13 +243,13 @@ func accessModeFromGRPC(accessMode *swarmapi.VolumeAccessMode) *volumetypes.Volu
 	return convertedAccessMode
 }
 
-func volumeSecretsFromGRPC(secrets []*swarmapi.VolumeSecret) []volumetypes.VolumeSecret {
+func volumeSecretsFromGRPC(secrets []*swarmapi.VolumeSecret) []volumetypes.Secret {
 	if secrets == nil {
 		return nil
 	}
-	convertedSecrets := make([]volumetypes.VolumeSecret, len(secrets))
+	convertedSecrets := make([]volumetypes.Secret, len(secrets))
 	for i, secret := range secrets {
-		convertedSecrets[i] = volumetypes.VolumeSecret{
+		convertedSecrets[i] = volumetypes.Secret{
 			Key:    secret.Key,
 			Secret: secret.Secret,
 		}
@@ -307,23 +289,23 @@ func topologyFromGRPC(top *swarmapi.Topology) volumetypes.Topology {
 	}
 }
 
-func capacityRangeFromGRPC(capacity *swarmapi.CapacityRange) *volumetypes.VolumeCapacityRange {
+func capacityRangeFromGRPC(capacity *swarmapi.CapacityRange) *volumetypes.CapacityRange {
 	if capacity == nil {
 		return nil
 	}
 
-	return &volumetypes.VolumeCapacityRange{
+	return &volumetypes.CapacityRange{
 		RequiredBytes: uint64(capacity.RequiredBytes),
 		LimitBytes:    uint64(capacity.LimitBytes),
 	}
 }
 
-func volumeAvailabilityFromGRPC(availability swarmapi.VolumeSpec_VolumeAvailability) volumetypes.VolumeAvailability {
+func volumeAvailabilityFromGRPC(availability swarmapi.VolumeSpec_VolumeAvailability) volumetypes.Availability {
 	switch availability {
 	case swarmapi.VolumeAvailabilityActive:
-		return volumetypes.VolumeAvailabilityActive
+		return volumetypes.AvailabilityActive
 	case swarmapi.VolumeAvailabilityPause:
-		return volumetypes.VolumeAvailabilityPause
+		return volumetypes.AvailabilityPause
 	}
-	return volumetypes.VolumeAvailabilityDrain
+	return volumetypes.AvailabilityDrain
 }

--- a/daemon/cluster/convert/volume_test.go
+++ b/daemon/cluster/convert/volume_test.go
@@ -45,20 +45,20 @@ func TestVolumeAvailabilityFromGRPC(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		in       swarmapi.VolumeSpec_VolumeAvailability
-		expected volumetypes.VolumeAvailability
+		expected volumetypes.Availability
 	}{
 		{
 			name:     "Active",
 			in:       swarmapi.VolumeAvailabilityActive,
-			expected: volumetypes.VolumeAvailabilityActive,
+			expected: volumetypes.AvailabilityActive,
 		}, {
 			name:     "Pause",
 			in:       swarmapi.VolumeAvailabilityPause,
-			expected: volumetypes.VolumeAvailabilityPause,
+			expected: volumetypes.AvailabilityPause,
 		}, {
 			name:     "Drain",
 			in:       swarmapi.VolumeAvailabilityDrain,
-			expected: volumetypes.VolumeAvailabilityDrain,
+			expected: volumetypes.AvailabilityDrain,
 		},
 	} {
 		tc := tc
@@ -74,7 +74,7 @@ func TestAccessModeFromGRPC(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		in       *swarmapi.VolumeAccessMode
-		expected *volumetypes.VolumeAccessMode
+		expected *volumetypes.AccessMode
 	}{
 		{
 			name: "MountVolume",
@@ -89,10 +89,10 @@ func TestAccessModeFromGRPC(t *testing.T) {
 					},
 				},
 			},
-			expected: &volumetypes.VolumeAccessMode{
-				Scope:   volumetypes.VolumeScopeSingleNode,
-				Sharing: volumetypes.VolumeSharingNone,
-				MountVolume: &volumetypes.VolumeTypeMount{
+			expected: &volumetypes.AccessMode{
+				Scope:   volumetypes.ScopeSingleNode,
+				Sharing: volumetypes.SharingNone,
+				MountVolume: &volumetypes.TypeMount{
 					FsType:     "foo",
 					MountFlags: []string{"one", "two"},
 				},
@@ -106,10 +106,10 @@ func TestAccessModeFromGRPC(t *testing.T) {
 					Block: &swarmapi.VolumeAccessMode_BlockVolume{},
 				},
 			},
-			expected: &volumetypes.VolumeAccessMode{
-				Scope:       volumetypes.VolumeScopeSingleNode,
-				Sharing:     volumetypes.VolumeSharingNone,
-				BlockVolume: &volumetypes.VolumeTypeBlock{},
+			expected: &volumetypes.AccessMode{
+				Scope:       volumetypes.ScopeSingleNode,
+				Sharing:     volumetypes.SharingNone,
+				BlockVolume: &volumetypes.TypeBlock{},
 			},
 		},
 	} {
@@ -133,15 +133,15 @@ func TestVolumeCreateToGRPC(t *testing.T) {
 
 	spec := &volumetypes.ClusterVolumeSpec{
 		Group: "gronp",
-		AccessMode: &volumetypes.VolumeAccessMode{
-			Scope:   volumetypes.VolumeScopeMultiNode,
-			Sharing: volumetypes.VolumeSharingAll,
-			MountVolume: &volumetypes.VolumeTypeMount{
+		AccessMode: &volumetypes.AccessMode{
+			Scope:   volumetypes.ScopeMultiNode,
+			Sharing: volumetypes.SharingAll,
+			MountVolume: &volumetypes.TypeMount{
 				FsType:     "foo",
 				MountFlags: []string{"one", "two"},
 			},
 		},
-		Secrets: []volumetypes.VolumeSecret{
+		Secrets: []volumetypes.Secret{
 			{Key: "key1", Secret: "secret1"},
 			{Key: "key2", Secret: "secret2"},
 		},
@@ -153,7 +153,7 @@ func TestVolumeCreateToGRPC(t *testing.T) {
 			},
 			Preferred: []volumetypes.Topology{},
 		},
-		CapacityRange: &volumetypes.VolumeCapacityRange{
+		CapacityRange: &volumetypes.CapacityRange{
 			RequiredBytes: 1,
 			LimitBytes:    0,
 		},

--- a/daemon/cluster/volumes.go
+++ b/daemon/cluster/volumes.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	apitypes "github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/daemon/cluster/convert"
 	"github.com/docker/docker/errdefs"
@@ -30,7 +29,7 @@ func (c *Cluster) GetVolume(nameOrID string) (volumetypes.Volume, error) {
 }
 
 // GetVolumes returns all of the volumes matching the given options from a swarm cluster.
-func (c *Cluster) GetVolumes(options apitypes.VolumeListOptions) ([]*volumetypes.Volume, error) {
+func (c *Cluster) GetVolumes(options volumetypes.ListOptions) ([]*volumetypes.Volume, error) {
 	var volumes []*volumetypes.Volume
 	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
 		r, err := state.controlClient.ListVolumes(
@@ -104,7 +103,7 @@ func (c *Cluster) RemoveVolume(nameOrID string, force bool) error {
 }
 
 // UpdateVolume updates a volume in the swarm cluster.
-func (c *Cluster) UpdateVolume(nameOrID string, version uint64, volume volumetypes.VolumeUpdateBody) error {
+func (c *Cluster) UpdateVolume(nameOrID string, version uint64, volume volumetypes.UpdateOptions) error {
 	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
 		v, err := getVolume(ctx, state.controlClient, nameOrID)
 		if err != nil {
@@ -117,11 +116,11 @@ func (c *Cluster) UpdateVolume(nameOrID string, version uint64, volume volumetyp
 
 		if volume.Spec != nil {
 			switch volume.Spec.Availability {
-			case volumetypes.VolumeAvailabilityActive:
+			case volumetypes.AvailabilityActive:
 				v.Spec.Availability = swarmapi.VolumeAvailabilityActive
-			case volumetypes.VolumeAvailabilityPause:
+			case volumetypes.AvailabilityPause:
 				v.Spec.Availability = swarmapi.VolumeAvailabilityPause
-			case volumetypes.VolumeAvailabilityDrain:
+			case volumetypes.AvailabilityDrain:
 				v.Spec.Availability = swarmapi.VolumeAvailabilityDrain
 			}
 			// if default empty value, change nothing.

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -73,6 +73,16 @@ keywords: "API, Docker, rcli, REST, documentation"
   syntax, `<IDType>://<ID>` is now recognised. Support for specific `<IDType>` values
   depends on the underlying implementation and Windows version. This change is not
   versioned, and affects all API versions if the daemon has this patch.
+* `POST /volumes/create` now accepts a new `ClusterVolumeSpec` to create a cluster
+  volume (CNI). This option can only be used if the daemon is a Swarm manager.
+  The Volume response on creation now also can contain a `ClusterVolume` field
+  with information about the created volume.
+* Volume information returned by `GET /volumes/{name}`, `GET /volumes` and
+  `GET /system/df` can now contain a `ClusterVolume` if the volume is a cluster
+  volume (requires the daemon to be a Swarm manager).
+* The `Volume` type, as returned by `Added new `ClusterVolume` fields 
+* Added a new `PUT /volumes{name}` endpoint to update cluster volumes (CNI).
+  Cluster volumes are only supported if the daemon is a Swarm manager.
 
 ## v1.41 API changes
 


### PR DESCRIPTION
review suggestions from https://github.com/moby/moby/pull/41982 https://github.com/moby/moby/pull/41982#pullrequestreview-968121287

I was drafting these along while doing review, so may as well open a
PR; summary of changes (note that they haven't been tested ':-));

- moved types.VolumeListOptions to volume.ListOptions
- removed unused types.VolumeCreateResponse
- renamed volume.VolumeUpdateBody to volume.UpdateOptions
- removed various `Volume` prefixes from new types in api/types/volume
- changed publish state enum values to use hyphens instead of spaces (e.g. "pending publish" -> "pending-publish")
- fixed swagger definition (`POST /volumes/{name}/update` -> `PUT /volumes/{name}`)
- quick attempt at updating docs/api/version-history.md


